### PR TITLE
Fix calling a function with missing arguments

### DIFF
--- a/src/short-and-sweet.js
+++ b/src/short-and-sweet.js
@@ -101,7 +101,7 @@ export default ((w) => {
     // assist timer
     let isFirstUpdate = true;
     
-    const limit = (element, maxlength) => {
+    const limit = (maxlength) => {
       element.value = element.value.substr(0, maxlength);
     }
 
@@ -115,7 +115,7 @@ export default ((w) => {
       
       // limit textarea value to the maxlength
       if (overflowing) {
-        limit(element, maxlength);
+        limit(maxlength);
       }
 
       // current length (after limiting)

--- a/src/short-and-sweet.js
+++ b/src/short-and-sweet.js
@@ -101,7 +101,7 @@ export default ((w) => {
     // assist timer
     let isFirstUpdate = true;
     
-    const limit = (maxlength) => {
+    const limit = (element, maxlength) => {
       element.value = element.value.substr(0, maxlength);
     }
 


### PR DESCRIPTION
The function limit should have one argument: 

Current code:
```js
    const limit = (maxlength) => {
      element.value = element.value.substr(0, maxlength);
    }

```

Which is called like:

```js
      if (overflowing) {
        limit(element, maxlength);
      }
```

And results to nullifying the content of the textarea